### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/public/js/jquery.flexslider.js
+++ b/public/js/jquery.flexslider.js
@@ -71,7 +71,7 @@
           return false;
         }());
         // CONTROLSCONTAINER:
-        if (slider.vars.controlsContainer !== "") slider.controlsContainer = $(slider.vars.controlsContainer).length > 0 && $(slider.vars.controlsContainer);
+        if (slider.vars.controlsContainer !== "") slider.controlsContainer = $(slider).find(slider.vars.controlsContainer).length > 0 && $(slider).find(slider.vars.controlsContainer);
         // MANUAL:
         if (slider.vars.manualControls !== "") slider.manualControls = $(slider.vars.manualControls).length > 0 && $(slider.vars.manualControls);
 


### PR DESCRIPTION
Potential fix for [https://github.com/zaitera/zaitera.github.io/security/code-scanning/4](https://github.com/zaitera/zaitera.github.io/security/code-scanning/4)

To fix the problem, we need to ensure that the `controlsContainer` property is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the `controlsContainer` property to the jQuery constructor. This change will prevent the possibility of evaluating the input as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
