### PR TITLE
Potential fix for code scanning alert no. 30: Unsafe HTML constructed from library input

### DIFF
--- a/public/js/jquery.flexslider.js
+++ b/public/js/jquery.flexslider.js
@@ -844,7 +844,9 @@
         var sliderOffset, arr;
 
         if (type === "init") {
-          slider.viewport = $('<div class="' + namespace + 'viewport"></div>').css({"overflow": "hidden", "position": "relative"}).appendTo(slider).append(slider.container);
+          var viewportDiv = document.createElement('div');
+          viewportDiv.className = namespace + 'viewport';
+          slider.viewport = $(viewportDiv).css({"overflow": "hidden", "position": "relative"}).appendTo(slider).append(slider.container);
           // INFINITE LOOP:
           slider.cloneCount = 0;
           slider.cloneOffset = 0;


### PR DESCRIPTION
Potential fix for [https://github.com/zaitera/zaitera.github.io/security/code-scanning/30](https://github.com/zaitera/zaitera.github.io/security/code-scanning/30)

To fix the problem, we need to ensure that the `namespace` variable is sanitized before being used to construct HTML. This can be done by using a safe API to create the HTML element or by sanitizing the `namespace` value.

The best way to fix this without changing existing functionality is to use the `document.createElement` method to create the `div` element and set its class name using the `className` property. This approach avoids directly injecting potentially unsafe HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
